### PR TITLE
add content type optitional filter

### DIFF
--- a/app/controller/item_controller.go
+++ b/app/controller/item_controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/12ev09/info-demo-backend/app/domain"
@@ -24,7 +25,18 @@ func NewItemController(itemUsecase usecase.ItemUsecase) ItemController {
 }
 
 func (c *itemController) GetItems(ctx echo.Context) error {
-	items, err := c.itemUsecase.GetItems()
+	type params struct {
+		ContentType int `query:"type"`
+	}
+
+	p := params{}
+	if err := ctx.Bind(&p); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	log.Print(p.ContentType)
+
+	items, err := c.itemUsecase.GetItems(p.ContentType)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/app/repository/item_repository.go
+++ b/app/repository/item_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/12ev09/info-demo-backend/app/domain"
 	"github.com/jmoiron/sqlx"
 )
 
 type ItemRepository interface {
-	GetItems() ([]domain.Item, error)
+	GetItems(contentType int) ([]domain.Item, error)
 	PostItem(domain.Item) error
 }
 
@@ -18,10 +21,26 @@ func NewItemRepository(db *sqlx.DB) ItemRepository {
 	return &itemRepository{db: db}
 }
 
-func (i *itemRepository) GetItems() ([]domain.Item, error) {
+func (i *itemRepository) GetItems(contentType int) ([]domain.Item, error) {
 	var items []domain.Item
-	if err := i.db.Select(&items, "SELECT id, title, isbn, publisher_name,sales_date,content_type FROM items"); err != nil {
+
+	args := []string{}
+
+	if contentType != 0 {
+		args = append(args, fmt.Sprintf("where content_type=%d", contentType))
+	}
+
+	rows, err := i.db.Queryx(fmt.Sprintf("SELECT * from items %s", strings.Join(args, " ")))
+	if err != nil {
 		return nil, err
+	}
+
+	for rows.Next() {
+		item := domain.Item{}
+		if err := rows.StructScan(&item); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
 	}
 
 	return items, nil

--- a/app/usecase/item_interactor.go
+++ b/app/usecase/item_interactor.go
@@ -15,8 +15,8 @@ func NewItemInteractor(itemRepository repository.ItemRepository) ItemUsecase {
 	}
 }
 
-func (i *itemInteractor) GetItems() ([]domain.Item, error) {
-	items, err := i.itemRepository.GetItems()
+func (i *itemInteractor) GetItems(contentType int) ([]domain.Item, error) {
+	items, err := i.itemRepository.GetItems(contentType)
 	if err != nil {
 		return nil, err
 	}

--- a/app/usecase/item_usecase.go
+++ b/app/usecase/item_usecase.go
@@ -3,6 +3,6 @@ package usecase
 import "github.com/12ev09/info-demo-backend/app/domain"
 
 type ItemUsecase interface {
-	GetItems() ([]domain.Item, error)
+	GetItems(contentType int) ([]domain.Item, error)
 	PostItem(domain.Item) error
 }


### PR DESCRIPTION
## issue

* https://github.com/12ev09/info-demo-backend/issues/5

## やったこと

検索フィルターに`content_type`を追加

``` go
func (i *itemRepository) GetItems(contentType int) ([]domain.Item, error) {
	var items []domain.Item

	args := []string{}

	if contentType != 0 {
		args = append(args, fmt.Sprintf("where content_type=%d", contentType))
	}

	rows, err := i.db.Queryx(fmt.Sprintf("SELECT * from items %s", strings.Join(args, " ")))
	if err != nil {
		return nil, err
	}

	for rows.Next() {
		item := domain.Item{}
		if err := rows.StructScan(&item); err != nil {
			return nil, err
		}
		items = append(items, item)
	}

	return items, nil
}
```
備考
- `StructScan`はsliceには使えない